### PR TITLE
feat(containers): add support for 0.22.0-alpha2

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,10 @@ Current plans are to add more tests and QoL features:
 Supported Zeebe versions
 ========================
 
-- 0.20.0
-- 0.21.0-alpha1
-- 0.21.0-alpha2
+- 0.20.1
+- 0.21.1
 - 0.22.0-alpha1
+- 0.22.0-alpha2
 
 Quickstart
 ==========
@@ -41,7 +41,7 @@ Add the project to your dependencies:
 <dependency>
   <groupId>io.zeebe</groupId>
   <artifactId>zeebe-test-container</artifactId>
-  <version>0.22.0-alpha1</version>
+  <version>0.22.0-alpha2</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <artifactId>zeebe-test-container</artifactId>
   <packaging>jar</packaging>
   <groupId>io.zeebe</groupId>
-  <version>0.21.0-SNAPSHOT</version>
+  <version>0.22.0-SNAPSHOT</version>
   <inceptionYear>2019</inceptionYear>
   <url>https://github.com/zeebe-io/zeebe-test-container</url>
 
@@ -41,7 +41,7 @@
     <version.log4j>2.11.1</version.log4j>
     <version.slf4j>1.7.29</version.slf4j>
     <version.testcontainers>1.12.3</version.testcontainers>
-    <version.zeebe>0.22.0-alpha1</version.zeebe>
+    <version.zeebe>0.22.0-alpha2</version.zeebe>
 
     <!-- plugin version -->
     <plugin.version.checkstyle>3.1.0</plugin.version.checkstyle>

--- a/src/main/java/io/zeebe/containers/ZeebeContainer.java
+++ b/src/main/java/io/zeebe/containers/ZeebeContainer.java
@@ -83,4 +83,8 @@ public interface ZeebeContainer<SELF extends ZeebeContainer<SELF>> extends Conta
       throw new UncheckedIOException(e);
     }
   }
+
+  default SELF withAdvertisedHost(final String advertisedHost) {
+    return withEnv(ZeebeEnvironment.ZEEBE_ADVERTISED_HOST, advertisedHost);
+  }
 }

--- a/src/main/java/io/zeebe/containers/ZeebeEnvironment.java
+++ b/src/main/java/io/zeebe/containers/ZeebeEnvironment.java
@@ -17,7 +17,8 @@ package io.zeebe.containers;
 
 public enum ZeebeEnvironment implements Environment {
   ZEEBE_LOG_LEVEL,
-  ATOMIX_LOG_LEVEL;
+  ATOMIX_LOG_LEVEL,
+  ZEEBE_ADVERTISED_HOST;
 
   private final String variableName;
 

--- a/src/test/java/io/zeebe/containers/SupportedVersion.java
+++ b/src/test/java/io/zeebe/containers/SupportedVersion.java
@@ -18,7 +18,8 @@ package io.zeebe.containers;
 public enum SupportedVersion {
   ZEEBE_0_20_1("0.20.1"),
   ZEEBE_0_21_1("0.21.1"),
-  ZEEBE_0_22_0_alpha1("0.22.0-alpha1");
+  ZEEBE_0_22_0_alpha1("0.22.0-alpha1"),
+  ZEEBE_0_22_0_alpha2("0.22.0-alpha2");
 
   private final String version;
 


### PR DESCRIPTION
- upgrades Zeebe version to 0.22.0-alpha2
- adds `ZeebeContainer#withAdvertisedHost`