### PR TITLE
#21 update for Zeebe 0.22.1 final

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Zeebe Test Container
 
 Easily test your application against a containerized, configurable Zeebe instance.
 
-> **NOTE**: the module uses the same versions as the Zeebe version it targets, e.g. version `0.21.0-alpha2` targets Zeebe `0.21.0-alpha2`. 
+> **NOTE**: the module uses the same versions as the Zeebe version it targets, e.g. version `0.21.0-alpha2` targets Zeebe `0.21.0-alpha2`.
             While we try to maintain backwards compatibility it is not always guaranteed.
 
 Please refer to [testcontainers.org](https://testcontainers.org) for general documentation on how to
@@ -29,8 +29,7 @@ Supported Zeebe versions
 
 - 0.20.1
 - 0.21.1
-- 0.22.0-alpha1
-- 0.22.0-alpha2
+- 0.22.1
 
 Quickstart
 ==========
@@ -41,7 +40,7 @@ Add the project to your dependencies:
 <dependency>
   <groupId>io.zeebe</groupId>
   <artifactId>zeebe-test-container</artifactId>
-  <version>0.22.0-alpha2</version>
+  <version>0.22.1</version>
 </dependency>
 ```
 
@@ -79,7 +78,7 @@ class MyFeatureTest {
   private final BrokerEnvironment zeebeEnv = new BrokerEnvironment()
     .withPartitionCount(3)
     .withReplicationFactor(1);
-  
+
   @Rule
   public ZeebeBrokerContainer zeebe = new ZeebeBrokerContainer(zeebeEnv);
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <artifactId>zeebe-test-container</artifactId>
   <packaging>jar</packaging>
   <groupId>io.zeebe</groupId>
-  <version>0.22.0-SNAPSHOT</version>
+  <version>0.22.1</version>
   <inceptionYear>2019</inceptionYear>
   <url>https://github.com/zeebe-io/zeebe-test-container</url>
 
@@ -40,8 +40,8 @@
     <version.kafka>2.1.0</version.kafka>
     <version.log4j>2.11.1</version.log4j>
     <version.slf4j>1.7.29</version.slf4j>
-    <version.testcontainers>1.12.3</version.testcontainers>
-    <version.zeebe>0.22.0-alpha2</version.zeebe>
+    <version.testcontainers>1.12.4</version.testcontainers>
+    <version.zeebe>0.22.1</version.zeebe>
 
     <!-- plugin version -->
     <plugin.version.checkstyle>3.1.0</plugin.version.checkstyle>

--- a/src/main/java/io/zeebe/containers/SupportedVersion.java
+++ b/src/main/java/io/zeebe/containers/SupportedVersion.java
@@ -15,20 +15,39 @@
  */
 package io.zeebe.containers;
 
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
 public enum SupportedVersion {
-  ZEEBE_0_20_1("0.20.1"),
-  ZEEBE_0_21_1("0.21.1"),
-  ZEEBE_0_22_0_alpha1("0.22.0-alpha1"),
-  ZEEBE_0_22_0_alpha2("0.22.0-alpha2");
+  ZEEBE_0_20_1("0.20.1", ".*Broker is ready.*"),
+  ZEEBE_0_21_1("0.21.1", ".*Broker is ready.*"),
+  ZEEBE_0_22_1("0.22.1", ".* succeeded. Started.*");
 
+  private static final Map<String, SupportedVersion> LOOKUP_MAP = new HashMap<>();
   private final String version;
+  private final String logStringRegex;
 
-  SupportedVersion(final String version) {
+  static {
+    Arrays.stream(SupportedVersion.values())
+        .forEach(version -> LOOKUP_MAP.put(version.version(), version));
+  }
+
+  SupportedVersion(final String version, final String logStringRegex) {
     this.version = version;
+    this.logStringRegex = logStringRegex;
   }
 
   public String version() {
     return version;
+  }
+
+  public String logStringRegex() {
+    return logStringRegex;
+  }
+
+  public static SupportedVersion fromVersion(String version) {
+    return LOOKUP_MAP.get(version);
   }
 
   @Override

--- a/src/main/java/io/zeebe/containers/ZeebeBrokerContainer.java
+++ b/src/main/java/io/zeebe/containers/ZeebeBrokerContainer.java
@@ -33,6 +33,7 @@ public class ZeebeBrokerContainer extends GenericContainer<ZeebeBrokerContainer>
   protected String host;
   protected int portOffset;
   protected boolean embedGateway;
+  protected String version;
 
   public ZeebeBrokerContainer() {
     this(ZeebeDefaults.getInstance().getDefaultVersion());
@@ -44,6 +45,7 @@ public class ZeebeBrokerContainer extends GenericContainer<ZeebeBrokerContainer>
 
   public ZeebeBrokerContainer(final String image, final String version) {
     super(image + ":" + version);
+    this.version = version;
     applyDefaultConfiguration();
   }
 
@@ -93,8 +95,9 @@ public class ZeebeBrokerContainer extends GenericContainer<ZeebeBrokerContainer>
 
   public void applyDefaultConfiguration() {
     final String defaultHost = "zeebe-broker-" + Base58.randomString(6);
-    setWaitStrategy(new LogMessageWaitStrategy().withRegEx(".*Broker is ready.*"));
-
+    setWaitStrategy(
+        new LogMessageWaitStrategy()
+            .withRegEx(SupportedVersion.fromVersion(version).logStringRegex()));
     withHost(defaultHost)
         .withPartitionCount(1)
         .withReplicationFactor(1)


### PR DESCRIPTION
- removed alpha versions, all supported versions are final now
- WIP: tests run through in IDE, but not on command line -> container timeouts for cluster tests
- storing version in ZeebeBrokerContainer so we can retrieve the correct log output (stored in Enum now)
- moved SupportedVersion to make it accessible from both test and implementation