### PR TITLE
chore(containers): improve wait strategy

### DIFF
--- a/src/main/java/io/zeebe/containers/BrokerWaitStrategy.java
+++ b/src/main/java/io/zeebe/containers/BrokerWaitStrategy.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright © 2019 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.containers;
+
+import com.github.dockerjava.api.command.InspectContainerResponse;
+import java.time.Duration;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import org.testcontainers.containers.wait.strategy.HostPortWaitStrategy;
+import org.testcontainers.containers.wait.strategy.HttpWaitStrategy;
+import org.testcontainers.containers.wait.strategy.WaitStrategy;
+import org.testcontainers.containers.wait.strategy.WaitStrategyTarget;
+
+public class BrokerWaitStrategy implements WaitStrategy {
+
+  private final WaitStrategy readyCheck;
+  private final WaitStrategy commandApiCheck;
+
+  public BrokerWaitStrategy() {
+    readyCheck =
+        new HttpWaitStrategy()
+            .forPath("/ready")
+            .forPort(ZeebePort.MONITORING_API.getPort())
+            .forStatusCode(204)
+            .withReadTimeout(Duration.ofSeconds(10));
+    commandApiCheck = new HostPortWaitStrategy();
+  }
+
+  @Override
+  public void waitUntilReady(WaitStrategyTarget waitStrategyTarget) {
+    readyCheck.waitUntilReady(waitStrategyTarget);
+    commandApiCheck.waitUntilReady(new BrokerWaitStrategyTarget(waitStrategyTarget));
+  }
+
+  @Override
+  public WaitStrategy withStartupTimeout(Duration startupTimeout) {
+    readyCheck.withStartupTimeout(startupTimeout);
+    commandApiCheck.withStartupTimeout(startupTimeout);
+    return this;
+  }
+
+  private static final class BrokerWaitStrategyTarget implements WaitStrategyTarget {
+
+    private final WaitStrategyTarget waitStrategyTarget;
+
+    public BrokerWaitStrategyTarget(WaitStrategyTarget waitStrategyTarget) {
+      this.waitStrategyTarget = waitStrategyTarget;
+    }
+
+    @Override
+    public List<Integer> getExposedPorts() {
+      return waitStrategyTarget.getExposedPorts();
+    }
+
+    @Override
+    public InspectContainerResponse getContainerInfo() {
+      return waitStrategyTarget.getContainerInfo();
+    }
+
+    @Override
+    public Set<Integer> getLivenessCheckPortNumbers() {
+      return Collections.singleton(
+          waitStrategyTarget.getMappedPort(ZeebePort.COMMAND_API.getPort()));
+    }
+  }
+}

--- a/src/main/java/io/zeebe/containers/SupportedVersion.java
+++ b/src/main/java/io/zeebe/containers/SupportedVersion.java
@@ -15,39 +15,20 @@
  */
 package io.zeebe.containers;
 
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Map;
-
 public enum SupportedVersion {
-  ZEEBE_0_20_1("0.20.1", ".*Broker is ready.*"),
-  ZEEBE_0_21_1("0.21.1", ".*Broker is ready.*"),
-  ZEEBE_0_22_1("0.22.1", ".* succeeded. Started.*");
+  ZEEBE_0_20_1("0.20.1"),
+  ZEEBE_0_21_1("0.21.1"),
+  ZEEBE_0_22_1("0.22.1"),
+  SNAPSHOT("SNAPSHOT");
 
-  private static final Map<String, SupportedVersion> LOOKUP_MAP = new HashMap<>();
   private final String version;
-  private final String logStringRegex;
 
-  static {
-    Arrays.stream(SupportedVersion.values())
-        .forEach(version -> LOOKUP_MAP.put(version.version(), version));
-  }
-
-  SupportedVersion(final String version, final String logStringRegex) {
+  SupportedVersion(final String version) {
     this.version = version;
-    this.logStringRegex = logStringRegex;
   }
 
   public String version() {
     return version;
-  }
-
-  public String logStringRegex() {
-    return logStringRegex;
-  }
-
-  public static SupportedVersion fromVersion(String version) {
-    return LOOKUP_MAP.get(version);
   }
 
   @Override

--- a/src/main/java/io/zeebe/containers/ZeebeBrokerContainer.java
+++ b/src/main/java/io/zeebe/containers/ZeebeBrokerContainer.java
@@ -22,7 +22,6 @@ import java.util.Objects;
 import java.util.Set;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
-import org.testcontainers.containers.wait.strategy.LogMessageWaitStrategy;
 import org.testcontainers.utility.Base58;
 
 @SuppressWarnings({"WeakerAccess", "UnusedReturnValue"})
@@ -30,6 +29,7 @@ public class ZeebeBrokerContainer extends GenericContainer<ZeebeBrokerContainer>
     implements ZeebeContainer<ZeebeBrokerContainer>,
         ZeebeGatewayContainer<ZeebeBrokerContainer>,
         ZeebeNetworkable {
+
   protected String host;
   protected int portOffset;
   protected boolean embedGateway;
@@ -95,9 +95,8 @@ public class ZeebeBrokerContainer extends GenericContainer<ZeebeBrokerContainer>
 
   public void applyDefaultConfiguration() {
     final String defaultHost = "zeebe-broker-" + Base58.randomString(6);
-    setWaitStrategy(
-        new LogMessageWaitStrategy()
-            .withRegEx(SupportedVersion.fromVersion(version).logStringRegex()));
+    setWaitStrategy(new BrokerWaitStrategy());
+
     withHost(defaultHost)
         .withPartitionCount(1)
         .withReplicationFactor(1)


### PR DESCRIPTION
## Description

Changes the wait strategy to wait for a 204 response from the `/ready` endpoint and for the command API to be ready to accept commands. This has the advantage of not being dependent on broker logs and expanding the supported zeebe versions from 0.20.1, 0.21.1 and 0.22.1 to all versions that support the `/ready` endpoint on the 9600 port. It's also possible to use zeebe-test-container with non semver version like SNAPSHOT.

## Related issues


closes #37 

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
