### PR TITLE
feat(containers): support graceful shutdown

### DIFF
--- a/src/main/java/io/zeebe/containers/ZeebeContainer.java
+++ b/src/main/java/io/zeebe/containers/ZeebeContainer.java
@@ -24,12 +24,14 @@ import java.nio.channels.FileChannel;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Duration;
 import java.util.Collection;
 import org.slf4j.event.Level;
 import org.testcontainers.containers.Container;
 import org.testcontainers.utility.MountableFile;
 
 public interface ZeebeContainer<SELF extends ZeebeContainer<SELF>> extends Container<SELF> {
+
   default SELF withEnv(final Environment envVar, final String value) {
     return withEnv(envVar.variable(), value);
   }
@@ -86,5 +88,17 @@ public interface ZeebeContainer<SELF extends ZeebeContainer<SELF>> extends Conta
 
   default SELF withAdvertisedHost(final String advertisedHost) {
     return withEnv(ZeebeEnvironment.ZEEBE_ADVERTISED_HOST, advertisedHost);
+  }
+
+  /**
+   * Attempts to stop the container gracefully. If it times out, the container is abruptly killed.
+   *
+   * @param timeout must be greater than 1 second
+   */
+  default void shutdownGracefully(Duration timeout) {
+    getDockerClient()
+        .stopContainerCmd(getContainerId())
+        .withTimeout((int) timeout.getSeconds())
+        .exec();
   }
 }


### PR DESCRIPTION
## Description

Support shutting down the broker gracefully without killing the container (unless a timeout occurs).

## Related issues

closes #42 

## Pull Request Checklist

- [ ] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [ ] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [ ] If submitting code, please run `mvn clean install -DskipTests` locally before committing
