### PR TITLE
fix: fixes issue where user exposed ports are overwritten

### DIFF
--- a/src/main/java/io/zeebe/containers/ZeebeBrokerContainer.java
+++ b/src/main/java/io/zeebe/containers/ZeebeBrokerContainer.java
@@ -63,7 +63,7 @@ public class ZeebeBrokerContainer extends GenericContainer<ZeebeBrokerContainer>
     }
 
     super.configure();
-    withExposedPorts(exposedPorts.stream().map(ZeebePort::getPort).toArray(Integer[]::new));
+    exposedPorts.stream().map(ZeebePort::getPort).forEach(this::addExposedPort);
     withNetworkAliases(getInternalHost());
     withCreateContainerCmdModifier(createContainerCmd -> createContainerCmd.withName(name));
   }

--- a/src/main/java/io/zeebe/containers/ZeebeStandaloneGatewayContainer.java
+++ b/src/main/java/io/zeebe/containers/ZeebeStandaloneGatewayContainer.java
@@ -74,7 +74,7 @@ public class ZeebeStandaloneGatewayContainer
     }
 
     super.configure();
-    withExposedPorts(exposedPorts.stream().map(ZeebePort::getPort).toArray(Integer[]::new));
+    exposedPorts.stream().map(ZeebePort::getPort).forEach(this::addExposedPort);
     withNetworkAliases(getInternalHost());
     withCreateContainerCmdModifier(createContainerCmd -> createContainerCmd.withName(name));
   }

--- a/src/test/java/io/zeebe/containers/ZeebeBrokerContainerTest.java
+++ b/src/test/java/io/zeebe/containers/ZeebeBrokerContainerTest.java
@@ -20,10 +20,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.zeebe.client.ZeebeClient;
 import io.zeebe.client.api.response.BrokerInfo;
 import io.zeebe.client.api.response.Topology;
+import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
@@ -93,5 +95,24 @@ class ZeebeBrokerContainerTest {
     assertThat(brokerInfo.getAddress())
         .isEqualTo(container.getInternalAddress(ZeebePort.COMMAND_API));
     assertThat(brokerInfo.getPartitions()).hasSize(partitionsCount);
+  }
+
+  @Test
+  void shouldNotOverwritePort() {
+    // given
+    container =
+        new ZeebeBrokerContainer()
+            .withNetwork(network)
+            .withEmbeddedGateway(true)
+            .withExposedPorts(5701);
+
+    // when
+    container.start();
+
+    // then
+    assertThat(container.getMappedPort(5701)).isGreaterThan(0);
+    Arrays.stream(ZeebePort.values())
+        .map(ZeebePort::getPort)
+        .forEach(port -> assertThat(container.getMappedPort(port)).isGreaterThan(0));
   }
 }


### PR DESCRIPTION
## Description

If a user exposed ports while building his/her container, it was previously overwritten on start by us calling `withExposedPorts` instead of `addExposedPort`.

## Related issues

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
