### PR TITLE
chore(containers): remove debug exporter from default configuration

### DIFF
--- a/src/main/java/io/zeebe/containers/ZeebeBrokerContainer.java
+++ b/src/main/java/io/zeebe/containers/ZeebeBrokerContainer.java
@@ -101,7 +101,6 @@ public class ZeebeBrokerContainer extends GenericContainer<ZeebeBrokerContainer>
         .withPartitionCount(1)
         .withReplicationFactor(1)
         .withEmbeddedGateway(true)
-        .withDebug(false)
         .withClusterName(ZeebeDefaults.getInstance().getDefaultClusterName())
         .withClusterSize(1)
         .withContactPoints(Collections.emptyList())


### PR DESCRIPTION
## Description

* Default configuration enables debug exporter. There is no way to disable it. So this PR removes it from the default configuration.

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
