### PR TITLE
Ensure SLF4J logging implementation binding is a test dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -144,6 +144,7 @@
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-simple</artifactId>
       <version>${version.slf4j}</version>
+      <scope>test</scope>
     </dependency>
 
     <!-- assertions -->


### PR DESCRIPTION
## Description

The library uses the slf4j-simple implementation, but it's currently a dependency instead of a test dependency, which can result in projects having multiple bindings.

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
